### PR TITLE
avb: Remove processor type mention from system requirements

### DIFF
--- a/source/avb.rst
+++ b/source/avb.rst
@@ -36,9 +36,8 @@ applications.
 System Requirements
 -------------------
 
-This tutorial has been validated on two Coffee Lake based desktop machines with
-Intel(R) Ethernet Controller I210 connected back-to-back and Linux
-kernel version 4.19.
+This tutorial has been validated on two desktop machines with Intel(R) Ethernet
+Controller I210 connected back-to-back and Linux kernel version 4.19.
 
 Plugins Installation
 --------------------


### PR DESCRIPTION
While this tutorial was validated on Coffee Lake based machines, they are
effectively desktop ones - not some specific platform. Mentioning Coffee
Lake doesn't add any value to the tutorial, as other processors should
work just fine.