### PR TITLE
Add Read The Docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Documentation Status](https://readthedocs.org/projects/tsn/badge/?version=latest)](https://tsn.readthedocs.io/?badge=latest)
+
 # TSN Documentation Project for Linux
 
 Welcome to the Time-Sensitive Networking (TSN) Documentation project For Linux!


### PR DESCRIPTION
This adds the Read The Docs badge to the README file so documentation
status is shown on GitHub project home.