### PR TITLE
README: Add link to the rendered version of the tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Welcome to the Time-Sensitive Networking (TSN) Documentation project For Linux!
 This project provides a set of hands-on tutorials to help you get started with
 TSN on Linux systems.
 
+You can access the [rendered version here](https://tsn.readthedocs.io).
+
 The project uses Sphinx and the RTD theme. Make sure you have them installed:
 ```
 $ pip install -r requirements.txt


### PR DESCRIPTION
When people access the documentation project, it's helpful to have
some way to see how it looks like without having to build it first.