### PR TITLE
Add gettext to apt install

### DIFF
--- a/source/avb.rst
+++ b/source/avb.rst
@@ -54,7 +54,7 @@ install them:
 
         sudo apt install build-essential git meson flex bison glib2.0 \
                 libcmocka-dev autoconf libtool autopoint libncurses-dev \
-                libpulse-dev
+                libpulse-dev gettext
 
 In the instructions below, all plugins artifacts are installed in
 ``/usr/local`` so make sure your environment variables considered it.


### PR DESCRIPTION
Add gettext to apt install.

When I making the alsa-utils under ubuntu 19.10 server, it reports "mv: cannot stat `t-ja.gmo': No such file or directory".
install gettext fixed this.