### PR TITLE
The pmc command need network interface, too

### DIFF
--- a/source/avb.rst
+++ b/source/avb.rst
@@ -343,7 +343,7 @@ the UTC-TAI offset in the system, as below:
 
 .. code:: console
 
-        sudo pmc -u -b 0 -t 1 "SET GRANDMASTER_SETTINGS_NP clockClass 248 \
+        sudo pmc -u -b 0 -t 1 -i eth0 "SET GRANDMASTER_SETTINGS_NP clockClass 248 \
                 clockAccuracy 0xfe offsetScaledLogVariance 0xffff \
                 currentUtcOffset 37 leap61 0 leap59 0 currentUtcOffsetValid 1 \
                 ptpTimescale 1 timeTraceable 1 frequencyTraceable 0 \


### PR DESCRIPTION
If the NIC is no eth0 by default, this pmc command will do nothing usefull.