### PR TITLE
calc-cbs-params: fix off-by-one on locredit calculation

### DIFF
--- a/misc/calc-cbs-params.py
+++ b/misc/calc-cbs-params.py
@@ -26,7 +26,9 @@ def calc_class_a_credits(
     # loCredit for SR class A are calculated following the
     # equations L-10 and L-12, respectively.
     hicredit = math.ceil(idleslope_a * frame_non_sr / link_speed)
-    locredit = math.ceil(sendslope_a * max_frame_size_a / link_speed)
+    # locredit is a negative number, because of sendslope, and thus
+    # we need to use math.floor() for the ceiling of a negative number
+    locredit = math.floor(sendslope_a * max_frame_size_a / link_speed)
     return hicredit, locredit
 
 
@@ -61,7 +63,8 @@ def calc_class_b_credits(
                          ((frame_non_sr / (link_speed - idleslope_a)) +
                           (max_frame_size_a / link_speed)))
     # loCredit B is calculated following equation L-2.
-    locredit = math.ceil(sendslope_b * max_frame_size_b / link_speed)
+    # see comment in calc_class_a_credits() for why we use floor here
+    locredit = math.floor(sendslope_b * max_frame_size_b / link_speed)
     return hicredit, locredit
 
 


### PR DESCRIPTION
Hello everyone,
i think i found an off-by-one issue on locredit calculation, assuming that the intent of ``ceil`` was to always round up.
Let me know if you all agree.

If I am wrong, i still think we should add a comment since ``ceil()`` may not behave as "expected".

---
The locredit parameter is a rounded up integer from a floating-point division. Unfortunately, locredit is a negative number (as it is derived from sendslope), and the rounding up python function employed (math.ceil()) provides the relative (not absolute) rounded up value.

Thus, math.ceil(-4.2) is -4 and not -5.

Use math.floor() for this specific case.

Before this patch:
$ ./calc-cbs-params.py --stream class=a,transport=avtp-aaf,rate=8000,psize=384
Class A: idleslope 28800 sendslope -971200 hicredit 45 locredit -437
(...)

After this patch:
$ ./calc-cbs-params.py --stream class=a,transport=avtp-aaf,rate=8000,psize=384
Class A: idleslope 28800 sendslope -971200 hicredit 45 locredit -438
(...)